### PR TITLE
Add Jupyter LLM chat widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# new_ai_ui
+# LLM Notebook UI
+
+This project provides a simple Jupyter-based interface for chatting with Large Language Models (LLMs). The chat widget allows you to edit both the prompts you send and the responses from the model. Any edits immediately update the conversation history so that subsequent model calls use the modified text.
+
+## Features
+
+- Interactive chat widget that works directly in Jupyter notebooks.
+- Editable messages and model responses.
+- Pluggable provider system supporting:
+  - OpenAI ChatGPT
+  - Google Gemini
+  - Ollama (local models)
+- Easily extensible for other providers.
+
+## Installation
+
+Install the required packages in your environment:
+
+```bash
+pip install ipywidgets openai google-generativeai requests nbformat
+```
+
+## Usage
+
+Create a notebook and instantiate the chat UI with your provider of choice:
+
+```python
+from llm_notebook_ui import OpenAIProvider, LLMChat
+
+# Configure provider (expects `OPENAI_API_KEY` environment variable)
+provider = OpenAIProvider()
+
+# Display the chat widget
+chat = LLMChat(provider)
+```
+
+Try editing any message in the conversation; the history stored by the widget will be updated so future replies take those edits into account. See `examples/chat_example.ipynb` for a minimal working notebook.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pip install ipywidgets openai google-generativeai requests nbformat
 
 ## Usage
 
+There are two ways to interact with the models:
+
+### Chat widget
+
 Create a notebook and instantiate the chat UI with your provider of choice:
 
 ```python
@@ -34,4 +38,21 @@ provider = OpenAIProvider()
 chat = LLMChat(provider)
 ```
 
-Try editing any message in the conversation; the history stored by the widget will be updated so future replies take those edits into account. See `examples/chat_example.ipynb` for a minimal working notebook.
+Try editing any message in the conversation; the history stored by the widget will be updated so future replies take those edits into account.
+
+### Chat cell
+
+Load the IPython extension and create cells starting with `%%chat`:
+
+```python
+%load_ext llm_notebook_ui.magics
+```
+
+```python
+%%chat
+What is the capital of France?
+```
+
+The response appears in an editable text area. Edits are stored in the conversation context so the next `%%chat` cell uses your modified text.
+
+See `examples/chat_example.ipynb` for a minimal working notebook.

--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ What is the capital of France?
 
 The response appears in an editable text area. Edits are stored in the conversation context so the next `%%chat` cell uses your modified text.
 
+If widgets cannot be rendered in your environment, the output falls back to Markdown text which you can edit manually before running the next chat cell.
+
 See `examples/chat_example.ipynb` for a minimal working notebook.

--- a/examples/chat_example.ipynb
+++ b/examples/chat_example.ipynb
@@ -1,0 +1,1 @@
+{"nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": [{"id": "b6c9a237", "cell_type": "markdown", "source": "# LLM Chat Example", "metadata": {}}, {"id": "22b9a88f", "cell_type": "code", "metadata": {}, "execution_count": null, "source": "from llm_notebook_ui import OpenAIProvider, LLMChat\nprovider = OpenAIProvider()\nchat = LLMChat(provider)", "outputs": []}]}

--- a/examples/chat_example.ipynb
+++ b/examples/chat_example.ipynb
@@ -1,1 +1,48 @@
-{"nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": [{"id": "b6c9a237", "cell_type": "markdown", "source": "# LLM Chat Example", "metadata": {}}, {"id": "22b9a88f", "cell_type": "code", "metadata": {}, "execution_count": null, "source": "from llm_notebook_ui import OpenAIProvider, LLMChat\nprovider = OpenAIProvider()\nchat = LLMChat(provider)", "outputs": []}]}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b6c9a237",
+   "metadata": {},
+   "source": [
+    "# LLM Chat Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22b9a88f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_notebook_ui import OpenAIProvider, LLMChat\n",
+    "provider = OpenAIProvider()\n",
+    "chat = LLMChat(provider)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e2f2054",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext llm_notebook_ui.magics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5c974f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%chat\n",
+    "Hello"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llm_notebook_ui/__init__.py
+++ b/llm_notebook_ui/__init__.py
@@ -1,0 +1,12 @@
+"""Jupyter UI for chatting with language models."""
+
+from .provider import LLMProvider, OpenAIProvider, GeminiProvider, OllamaProvider
+from .chat import LLMChat
+
+__all__ = [
+    "LLMProvider",
+    "OpenAIProvider",
+    "GeminiProvider",
+    "OllamaProvider",
+    "LLMChat",
+]

--- a/llm_notebook_ui/__init__.py
+++ b/llm_notebook_ui/__init__.py
@@ -1,7 +1,8 @@
 """Jupyter UI for chatting with language models."""
 
 from .provider import LLMProvider, OpenAIProvider, GeminiProvider, OllamaProvider
-from .chat import LLMChat
+from .chat import LLMChat, ChatSession
+from .magics import load_chat_magics
 
 __all__ = [
     "LLMProvider",
@@ -9,4 +10,6 @@ __all__ = [
     "GeminiProvider",
     "OllamaProvider",
     "LLMChat",
+    "ChatSession",
+    "load_chat_magics",
 ]

--- a/llm_notebook_ui/chat.py
+++ b/llm_notebook_ui/chat.py
@@ -8,12 +8,34 @@ from IPython.display import display
 from .provider import LLMProvider, Message
 
 
-class LLMChat:
-    """Simple interactive chat widget for Jupyter notebooks."""
+
+class ChatSession:
+    """Maintain editable chat history."""
 
     def __init__(self, provider: LLMProvider):
         self.provider = provider
         self.messages: List[Message] = []
+
+    def add_message(self, role: str, content: str) -> int:
+        msg: Message = {"role": role, "content": content}
+        self.messages.append(msg)
+        return len(self.messages) - 1
+
+    def edit_message(self, index: int, new_content: str) -> None:
+        self.messages[index]["content"] = new_content
+
+    def ask(self, prompt: str) -> tuple[str, int]:
+        self.add_message("user", prompt)
+        reply = self.provider.generate(self.messages)
+        idx = self.add_message("assistant", reply)
+        return reply, idx
+
+
+class LLMChat:
+    """Simple interactive chat widget for Jupyter notebooks."""
+
+    def __init__(self, provider: LLMProvider, display_widget: bool = True):
+        self.session = ChatSession(provider)
         self.widgets: List[Textarea] = []
 
         self.input_area = Textarea(placeholder="Type your message", layout=Layout(width='100%'))
@@ -23,26 +45,37 @@ class LLMChat:
 
         controls = HBox([self.input_area, self.send_button])
         self.container = VBox([self.output_box, controls])
-        display(self.container)
+        if display_widget:
+            display(self.container)
 
     # Internal helpers -----------------------------------------------------
-    def _add_message(self, role: str, content: str):
-        msg: Message = {"role": role, "content": content}
-        self.messages.append(msg)
-        widget = Textarea(value=content, layout=Layout(width='100%'))
-        widget.observe(lambda c, w=widget: self._on_edit(w), names='value')
+    def _add_message(self, index: int):
+        msg = self.session.messages[index]
+        widget = Textarea(value=msg["content"], layout=Layout(width="100%"))
+        widget.observe(lambda c, i=index: self._on_edit(i, c["new"]), names="value")
         self.widgets.append(widget)
         self.output_box.children += (widget,)
 
-    def _on_edit(self, widget: Textarea):
-        index = self.widgets.index(widget)
-        self.messages[index]['content'] = widget.value
+    def _on_edit(self, index: int, new_value: str):
+        self.session.edit_message(index, new_value)
 
     def _on_send(self, _):
         user_text = self.input_area.value.strip()
         if not user_text:
             return
         self.input_area.value = ''
-        self._add_message('user', user_text)
-        reply = self.provider.generate(self.messages)
-        self._add_message('assistant', reply)
+        user_idx = self.session.add_message("user", user_text)
+        self._add_message(user_idx)
+        reply = self.session.provider.generate(self.session.messages)
+        assistant_idx = self.session.add_message("assistant", reply)
+        self._add_message(assistant_idx)
+
+    # Public API -----------------------------------------------------------
+    def send(self, text: str) -> str:
+        """Programmatically send a message and return the reply."""
+        user_idx = self.session.add_message("user", text)
+        reply = self.session.provider.generate(self.session.messages)
+        assistant_idx = self.session.add_message("assistant", reply)
+        self._add_message(user_idx)
+        self._add_message(assistant_idx)
+        return reply

--- a/llm_notebook_ui/chat.py
+++ b/llm_notebook_ui/chat.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+from ipywidgets import VBox, HBox, Textarea, Button, Layout
+from IPython.display import display
+
+from .provider import LLMProvider, Message
+
+
+class LLMChat:
+    """Simple interactive chat widget for Jupyter notebooks."""
+
+    def __init__(self, provider: LLMProvider):
+        self.provider = provider
+        self.messages: List[Message] = []
+        self.widgets: List[Textarea] = []
+
+        self.input_area = Textarea(placeholder="Type your message", layout=Layout(width='100%'))
+        self.send_button = Button(description="Send", button_style='primary')
+        self.send_button.on_click(self._on_send)
+        self.output_box = VBox()
+
+        controls = HBox([self.input_area, self.send_button])
+        self.container = VBox([self.output_box, controls])
+        display(self.container)
+
+    # Internal helpers -----------------------------------------------------
+    def _add_message(self, role: str, content: str):
+        msg: Message = {"role": role, "content": content}
+        self.messages.append(msg)
+        widget = Textarea(value=content, layout=Layout(width='100%'))
+        widget.observe(lambda c, w=widget: self._on_edit(w), names='value')
+        self.widgets.append(widget)
+        self.output_box.children += (widget,)
+
+    def _on_edit(self, widget: Textarea):
+        index = self.widgets.index(widget)
+        self.messages[index]['content'] = widget.value
+
+    def _on_send(self, _):
+        user_text = self.input_area.value.strip()
+        if not user_text:
+            return
+        self.input_area.value = ''
+        self._add_message('user', user_text)
+        reply = self.provider.generate(self.messages)
+        self._add_message('assistant', reply)

--- a/llm_notebook_ui/chat.py
+++ b/llm_notebook_ui/chat.py
@@ -10,21 +10,26 @@ from .provider import LLMProvider, Message
 
 
 class ChatSession:
-    """Maintain editable chat history."""
+    """Maintain editable chat history for a conversation."""
 
     def __init__(self, provider: LLMProvider):
+        """Create a new chat session bound to *provider*."""
         self.provider = provider
+        # Messages are stored as a list of ``{"role": str, "content": str}``.
         self.messages: List[Message] = []
 
     def add_message(self, role: str, content: str) -> int:
+        """Append a message and return its index."""
         msg: Message = {"role": role, "content": content}
         self.messages.append(msg)
         return len(self.messages) - 1
 
     def edit_message(self, index: int, new_content: str) -> None:
+        """Update a previously stored message."""
         self.messages[index]["content"] = new_content
 
     def ask(self, prompt: str) -> tuple[str, int]:
+        """Send *prompt* and return ``(reply, index)`` of the response."""
         self.add_message("user", prompt)
         reply = self.provider.generate(self.messages)
         idx = self.add_message("assistant", reply)
@@ -35,11 +40,15 @@ class LLMChat:
     """Simple interactive chat widget for Jupyter notebooks."""
 
     def __init__(self, provider: LLMProvider, display_widget: bool = True):
+        """Create and optionally display the chat widget."""
         self.session = ChatSession(provider)
         self.widgets: List[Textarea] = []
 
-        self.input_area = Textarea(placeholder="Type your message", layout=Layout(width='100%'))
-        self.send_button = Button(description="Send", button_style='primary')
+        # User input components -------------------------------------------------
+        self.input_area = Textarea(
+            placeholder="Type your message", layout=Layout(width="100%")
+        )
+        self.send_button = Button(description="Send", button_style="primary")
         self.send_button.on_click(self._on_send)
         self.output_box = VBox()
 
@@ -50,20 +59,25 @@ class LLMChat:
 
     # Internal helpers -----------------------------------------------------
     def _add_message(self, index: int):
+        """Create a Textarea widget for message ``index`` and display it."""
         msg = self.session.messages[index]
         widget = Textarea(value=msg["content"], layout=Layout(width="100%"))
-        widget.observe(lambda c, i=index: self._on_edit(i, c["new"]), names="value")
+        widget.observe(
+            lambda c, i=index: self._on_edit(i, c["new"]), names="value"
+        )
         self.widgets.append(widget)
         self.output_box.children += (widget,)
 
     def _on_edit(self, index: int, new_value: str):
+        """Callback when a widget's text changes."""
         self.session.edit_message(index, new_value)
 
     def _on_send(self, _):
+        """Handle clicks on the Send button."""
         user_text = self.input_area.value.strip()
         if not user_text:
             return
-        self.input_area.value = ''
+        self.input_area.value = ""
         user_idx = self.session.add_message("user", user_text)
         self._add_message(user_idx)
         reply = self.session.provider.generate(self.session.messages)
@@ -72,7 +86,7 @@ class LLMChat:
 
     # Public API -----------------------------------------------------------
     def send(self, text: str) -> str:
-        """Programmatically send a message and return the reply."""
+        """Programmatically send ``text`` and return the model's reply."""
         user_idx = self.session.add_message("user", text)
         reply = self.session.provider.generate(self.session.messages)
         assistant_idx = self.session.add_message("assistant", reply)

--- a/llm_notebook_ui/magics.py
+++ b/llm_notebook_ui/magics.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from IPython.core.magic import Magics, magics_class, cell_magic
+from IPython.display import display
+from ipywidgets import Textarea, Layout
+from IPython import get_ipython
+
+from .provider import LLMProvider, OpenAIProvider
+from .chat import ChatSession
+
+
+@magics_class
+class ChatMagics(Magics):
+    """Provide %%chat cell magic for editable conversations."""
+
+    def __init__(self, shell, provider: LLMProvider | None = None):
+        super().__init__(shell)
+        self.session = ChatSession(provider or OpenAIProvider())
+
+    @cell_magic
+    def chat(self, line: str, cell: str) -> None:
+        prompt = cell.strip()
+        if not prompt:
+            return
+        reply, idx = self.session.ask(prompt)
+        widget = Textarea(value=reply, layout=Layout(width="100%"))
+        widget.observe(lambda c, i=idx: self.session.edit_message(i, c["new"]), names="value")
+        display(widget)
+
+
+def load_chat_magics(provider: LLMProvider) -> None:
+    """Register the chat cell magic with a custom provider."""
+    ip = get_ipython()
+    if ip is None:
+        raise RuntimeError("load_chat_magics must run inside IPython")
+    ip.register_magics(ChatMagics(ip, provider))
+
+
+def load_ipython_extension(ip):
+    """Default extension entry point using OpenAI provider."""
+    ip.register_magics(ChatMagics(ip, OpenAIProvider()))

--- a/llm_notebook_ui/magics.py
+++ b/llm_notebook_ui/magics.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+"""IPython magics providing a ``%%chat`` cell magic."""
+
 from IPython.core.magic import Magics, magics_class, cell_magic
-from IPython.display import display
+from IPython.display import display, Markdown
 from ipywidgets import Textarea, Layout
 from IPython import get_ipython
 
@@ -11,25 +13,49 @@ from .chat import ChatSession
 
 @magics_class
 class ChatMagics(Magics):
-    """Provide %%chat cell magic for editable conversations."""
+    """Provide ``%%chat`` cell magic for editable conversations."""
 
     def __init__(self, shell, provider: LLMProvider | None = None):
+        """Create a new ``ChatMagics`` instance.
+
+        Parameters
+        ----------
+        shell:
+            The IPython shell instance.
+        provider:
+            Optional :class:`~llm_notebook_ui.provider.LLMProvider` to use for
+            generating responses. If omitted, :class:`OpenAIProvider` is used.
+        """
         super().__init__(shell)
         self.session = ChatSession(provider or OpenAIProvider())
 
     @cell_magic
-    def chat(self, line: str, cell: str) -> None:
+    def chat(self, line: str, cell: str):
+        """Execute the cell as a chat prompt.
+
+        The returned value is an editable :class:`ipywidgets.Textarea` containing
+        the model's response. Editing the text updates the stored conversation so
+        future prompts use the modified text. If widgets cannot be rendered, a
+        ``Markdown`` object is returned instead.
+        """
         prompt = cell.strip()
         if not prompt:
             return
         reply, idx = self.session.ask(prompt)
-        widget = Textarea(value=reply, layout=Layout(width="100%"))
-        widget.observe(lambda c, i=idx: self.session.edit_message(i, c["new"]), names="value")
-        display(widget)
+        try:
+            widget = Textarea(value=reply, layout=Layout(width="100%"))
+            widget.observe(
+                lambda c, i=idx: self.session.edit_message(i, c["new"]),
+                names="value",
+            )
+            # Returning the widget makes it appear as regular cell output
+            return widget
+        except Exception:  # pragma: no cover - fallback when widgets unavailable
+            return Markdown(reply)
 
 
 def load_chat_magics(provider: LLMProvider) -> None:
-    """Register the chat cell magic with a custom provider."""
+    """Register the ``%%chat`` cell magic using the given provider."""
     ip = get_ipython()
     if ip is None:
         raise RuntimeError("load_chat_magics must run inside IPython")
@@ -37,5 +63,5 @@ def load_chat_magics(provider: LLMProvider) -> None:
 
 
 def load_ipython_extension(ip):
-    """Default extension entry point using OpenAI provider."""
+    """Entry point for ``%load_ext`` using the :class:`OpenAIProvider`."""
     ip.register_magics(ChatMagics(ip, OpenAIProvider()))

--- a/llm_notebook_ui/provider.py
+++ b/llm_notebook_ui/provider.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import List, Dict
+
+import requests
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - optional
+    openai = None
+
+try:
+    import google.generativeai as genai
+except ImportError:  # pragma: no cover - optional
+    genai = None
+
+
+Message = Dict[str, str]
+
+
+class LLMProvider(ABC):
+    """Base class for language model providers."""
+
+    @abstractmethod
+    def generate(self, messages: List[Message]) -> str:
+        """Generate a response from the provider given the chat history."""
+
+
+class OpenAIProvider(LLMProvider):
+    """Use OpenAI's ChatGPT API."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None):
+        if openai is None:
+            raise RuntimeError("openai package is required for OpenAIProvider")
+        self.model = model
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY environment variable not set")
+        openai.api_key = self.api_key
+
+    def generate(self, messages: List[Message]) -> str:
+        response = openai.chat.completions.create(model=self.model, messages=messages)
+        return response.choices[0].message.content
+
+
+class GeminiProvider(LLMProvider):
+    """Use Google's Gemini API."""
+
+    def __init__(self, model: str = "gemini-pro", api_key: str | None = None):
+        if genai is None:
+            raise RuntimeError("google-generativeai package is required for GeminiProvider")
+        self.model = model
+        self.api_key = api_key or os.environ.get("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError("GEMINI_API_KEY environment variable not set")
+        genai.configure(api_key=self.api_key)
+        self._model = genai.GenerativeModel(self.model)
+
+    def generate(self, messages: List[Message]) -> str:
+        # Convert messages to text conversation for gemini
+        parts = []
+        for m in messages:
+            role = m.get("role")
+            content = m.get("content")
+            if role == "user":
+                parts.append(f"User: {content}")
+            else:
+                parts.append(f"Assistant: {content}")
+        prompt = "\n".join(parts)
+        response = self._model.generate_content(prompt)
+        return response.text
+
+
+class OllamaProvider(LLMProvider):
+    """Use a local Ollama instance."""
+
+    def __init__(self, model: str = "llama2", host: str = "http://localhost:11434"):  # pragma: no cover - network
+        self.model = model
+        self.host = host.rstrip("/")
+
+    def generate(self, messages: List[Message]) -> str:
+        prompt = "\n".join(m["content"] for m in messages)
+        url = f"{self.host}/api/generate"
+        resp = requests.post(url, json={"model": self.model, "prompt": prompt})
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response", "")

--- a/llm_notebook_ui/provider.py
+++ b/llm_notebook_ui/provider.py
@@ -32,6 +32,7 @@ class OpenAIProvider(LLMProvider):
     """Use OpenAI's ChatGPT API."""
 
     def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None):
+        """Create a provider for OpenAI's chat models."""
         if openai is None:
             raise RuntimeError("openai package is required for OpenAIProvider")
         self.model = model
@@ -41,6 +42,7 @@ class OpenAIProvider(LLMProvider):
         openai.api_key = self.api_key
 
     def generate(self, messages: List[Message]) -> str:
+        """Return the assistant reply for ``messages`` using ChatGPT."""
         response = openai.chat.completions.create(model=self.model, messages=messages)
         return response.choices[0].message.content
 
@@ -49,6 +51,7 @@ class GeminiProvider(LLMProvider):
     """Use Google's Gemini API."""
 
     def __init__(self, model: str = "gemini-pro", api_key: str | None = None):
+        """Use Google's Gemini API to generate text."""
         if genai is None:
             raise RuntimeError("google-generativeai package is required for GeminiProvider")
         self.model = model
@@ -59,7 +62,8 @@ class GeminiProvider(LLMProvider):
         self._model = genai.GenerativeModel(self.model)
 
     def generate(self, messages: List[Message]) -> str:
-        # Convert messages to text conversation for gemini
+        """Generate a reply for ``messages`` using Gemini."""
+        # Convert messages to a single text conversation string
         parts = []
         for m in messages:
             role = m.get("role")
@@ -77,10 +81,12 @@ class OllamaProvider(LLMProvider):
     """Use a local Ollama instance."""
 
     def __init__(self, model: str = "llama2", host: str = "http://localhost:11434"):  # pragma: no cover - network
+        """Use a local Ollama instance running on ``host``."""
         self.model = model
         self.host = host.rstrip("/")
 
     def generate(self, messages: List[Message]) -> str:
+        """Generate a reply from the local Ollama model."""
         prompt = "\n".join(m["content"] for m in messages)
         url = f"{self.host}/api/generate"
         resp = requests.post(url, json={"model": self.model, "prompt": prompt})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,6 @@ dependencies = [
     "openai>=1.0",
     "google-generativeai>=0.8",
     "requests",
+    "IPython",
+    "nbformat",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[project]
+name = "llm_notebook_ui"
+version = "0.1.0"
+description = "Jupyter-based UI for chatting with language models"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "ipywidgets>=8.0",
+    "openai>=1.0",
+    "google-generativeai>=0.8",
+    "requests",
+]


### PR DESCRIPTION
## Summary
- implement providers for OpenAI, Gemini, and Ollama
- create an editable chat widget built with ipywidgets
- provide a sample notebook and packaging metadata
- document usage in the README

## Testing
- `pip install ipywidgets openai google-generativeai > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pip install nbformat > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python -m pip check`
- `python -m compileall -q llm_notebook_ui`
- `python - <<'EOF'
from llm_notebook_ui import LLMChat, OpenAIProvider
print('modules imported')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686a510e5624832ebcf04f510a02aacd